### PR TITLE
## v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ This lists the changes between different versions of the RAID-SuperBLT basemod,
 the changes for the DLL are listed in their own changelog.
 Contributors other than maintainers are listed in parenthesis after specific changes.
 
+## v1.3.0
+
+- new mod options sub menu, matching the style of main menu and options.
+  - deprecated `inject_menu = "blt_options"`. use `inject_list` instead.
+  - `blt_options` injects can now handle the `icon` param, which can be any regular gui tweak icon.
+- injected lists can now automatically be sorted, if `blt_can_sort_list` is passed, and no injection injects by `point`.
+  - ..which now applies to the new `blt_options` list.
+- reworked MenuComponent creation, so that keyboard interactions should now be somewhat possible to implement in BLTMenus. (might require some more work to be fully usable, see MenuHelper changes)
+- other menu fixes:
+  - using the keyboard now works in mod options list and should not crash the game any longer.
+  - using internal raid_menu helper functions where possible.
+  - fixed special_btn_released when chat is focused.
+  - BLTMenu: fixed option description screen alignment and made font and color more raid-like.
+
 ## v1.2.10
 
 - added custom MultiChoice/stepper menu controls with icons instead of texts. (put icon_id or texture & texture_rect, instead of text or text_id in params.options)

--- a/lua/MenuComponentManager.lua
+++ b/lua/MenuComponentManager.lua
@@ -30,59 +30,62 @@ Hooks:PostHook(MenuComponentManager, "mouse_clicked", "BLT.MenuComponentManager.
 end)
 
 --- This handles injecting modded menus
-if BLT:GetGame() == "raid" then
-	Hooks:PostHook(MenuComponentManager, "set_active_components", "BLT.MenuComponentManager.set_active_components", function(self, components, node)
-		for name, comp in pairs(self._active_components) do
-			if BLT.raid_menus[name] then --Create only when necessary
-				if not comp.orig_create then
-					comp.orig_create = comp.create
-					comp.create = function(this, ...)
-						local r = comp.orig_create(this, ...)
-						for _, inject in pairs(BLT.raid_menus[name]) do
-							if inject.is_list then
-								RaidMenuHelper:InjectIntoAList(r, inject.point, inject.buttons, inject.list_name)
-							else
-								for _, btn in pairs(inject.buttons) do
-									if btn.inject_type then
-										BLTMenu[btn.inject_type](r, btn)
-									else
-										BLTMenu.MenuButton(r, btn)
-									end
-									if r._layout then
-										r:_layout()
-									end
+Hooks:PostHook(MenuComponentManager, "set_active_components", "BLT.MenuComponentManager.set_active_components", function(self, components, node)
+	for name, comp in pairs(self._active_components) do
+		if BLT.raid_menus[name] then --Create only when necessary
+			if not comp.orig_create then
+				comp.orig_create = comp.create
+				comp.create = function(this, ...)
+					local r = comp.orig_create(this, ...)
+					local list = nil
+					for _, inject in pairs(BLT.raid_menus[name]) do
+						if inject.is_list then
+							list = RaidMenuHelper:InjectIntoAList(r, inject.point, inject.buttons, inject.list_name)
+						else
+							for _, btn in pairs(inject.buttons) do
+								if btn.inject_type then
+									BLTMenu[btn.inject_type](r, btn)
+								else
+									BLTMenu.MenuButton(r, btn)
 								end
 							end
 						end
-						return r
 					end
+					if list and list._injected_data_source then
+						list:set_selected(false)
+						list:refresh_data()
+						list:show()
+						list:set_selected(true)
+					elseif r._layout then
+						r:_layout()
+					end
+					return r
 				end
 			end
 		end
-	end)
+	end
+end)
 
-	--- Port of PD2's "special_btn_released" callback function so it can be 
-	--- used in conjunction with "special_btn_pressed", which is already supported.
-	function MenuRenderer:special_btn_released(...)
-		if self:active_node_gui() and self:active_node_gui().special_btn_released and self:active_node_gui():special_btn_released(...) then
-			return true
-		end
-
-		return managers.menu_component:special_btn_released(...)
+--- Port of PD2's "special_btn_released" callback function so it can be 
+--- used in conjunction with "special_btn_pressed", which is already supported.
+function MenuRenderer:special_btn_released(...)
+	if self:active_node_gui() and self:active_node_gui().special_btn_released and self:active_node_gui():special_btn_released(...) then
+		return true
 	end
 
-	function MenuComponentManager:special_btn_released(...)
-		for _, component in pairs(self._active_components) do
-			if component.component_object and component.component_object.special_btn_released then
-				local handled = component.component_object:special_btn_released(...)
-				if handled then
-					return true
-				end
+	return managers.menu_component:special_btn_released(...)
+end
+
+function MenuComponentManager:special_btn_released(...)
+	for _, component in pairs(self._active_components) do
+		if component.component_object and component.component_object.special_btn_released then
+			local handled = component.component_object:special_btn_released(...)
+			if handled then
+				return true
 			end
 		end
-
-		if self._game_chat_gui and self._game_chat_gui:input_focus() == true then
-			return true
-		end
+	end
+	if managers.hud and managers.hud:hud_chat() and managers.hud:hud_chat():input_focus() == true then
+		return true
 	end
 end

--- a/req/raid/BLTMenu.lua
+++ b/req/raid/BLTMenu.lua
@@ -67,7 +67,10 @@ function BLTMenu:init(ws, fullscreen_ws, node, name, args)
     self._description_label = self:Label({
         name = "bltmenu_description_label",
         text = "",
-        ignore_align = true
+        ignore_align = true,
+		color = tweak_data.gui.colors.raid_dirty_white,
+		font = tweak_data.gui.fonts.din_compressed,
+		font_size = tweak_data.gui.font_sizes.small,
     })
     self:adjust_description_label()
     self:Align()
@@ -293,7 +296,7 @@ end
 function BLTMenu:adjust_description_label()
     local _, _, w, _ = BLT:make_fine_text(self._description_label._object)
     self._description_label:set_width(w)
-    self._description_label:set_right(managers.viewport:get_safe_rect_pixels().width)
+    self._description_label:set_right(self._description_label._object:parent():w())
 end
 
 function BLTMenu:_show_description(params)

--- a/req/raid/BLTRaidMenus.lua
+++ b/req/raid/BLTRaidMenus.lua
@@ -1,41 +1,72 @@
-BLTOptionsMenu = BLTOptionsMenu or class(BLTMenu)
-function BLTOptionsMenu:Init(root)
-    self:Title({
-        text = "menu_header_options_main_screen_name"
-    })
-    self:SubTitle({
-        text = "blt_options_menu_lua_mod_options"
-    })
+BLTOptionsMenu = BLTOptionsMenu or class(RaidMenuLeftOptions)
+
+function BLTOptionsMenu:init(ws, fullscreen_ws, node, component_name)
+    BLTOptionsMenu.super.init(self, ws, fullscreen_ws, node, component_name)
+    self.list_menu_options:show()
 end
 
-function BLTOptionsMenu:on_escape()
+function BLTOptionsMenu:_set_initial_data()
+    self._node.components.raid_menu_header:set_screen_name("menu_header_options_main_screen_name", "blt_options_menu_lua_mod_options")
+end
+
+function BLTOptionsMenu:_layout()
+    BLTOptionsMenu.super._layout(self)
+    self:_layout_list_menu()
+    self:bind_controller_inputs()
+end
+
+function BLTOptionsMenu:close()
+    BLTOptionsMenu.super.close(self)
     MenuCallbackHandler:perform_blt_save()
+end
+
+function BLTOptionsMenu:_layout_list_menu()
+    local list_menu_options_params = {
+        h = 640,
+        w = 480,
+        y = 144,
+        x = 0,
+        name = "blt_options_menu_list",
+        selection_enabled = true,
+        vertical_spacing = 2,
+        loop_items = true,
+        on_item_clicked_callback = callback(self, self, "_on_list_menu_options_item_selected"),
+        data_source_callback = callback(self, self, "_list_menu_options_data_source"),
+        item_class = RaidGUIControlListItemMenu,
+        blt_can_sort_list = true
+    }
+    self.list_menu_options = self._root_panel:create_custom_control(RaidGUIControlSingleSelectList, list_menu_options_params)
+    self.list_menu_options:set_selected(true)
+end
+
+function BLTOptionsMenu:_list_menu_options_data_source()
+    return {} -- filled by RaidMenuHelper:CreateMenu injection
 end
 
 BLTKeybindsMenu = BLTKeybindsMenu or class(BLTMenu)
 function BLTKeybindsMenu:Init(root)
     self:Title({text = "menu_header_options_main_screen_name"})
     self:SubTitle({text = "blt_options_menu_keybinds"})
-	local last_mod
-	for i, bind in ipairs(BLT.Keybinds:keybinds()) do
-		if bind:IsActive() and bind:ShowInMenu() then
-			-- Seperate keybinds by mod
-			if last_mod ~= bind:ParentMod() then
+    local last_mod
+    for i, bind in ipairs(BLT.Keybinds:keybinds()) do
+        if bind:IsActive() and bind:ShowInMenu() then
+            -- Seperate keybinds by mod
+            if last_mod ~= bind:ParentMod() then
                 self:Label({text = bind:ParentMod():GetName(), localize = false})
-			end
+            end
             self:KeyBind({
-				name = bind:Id(),
-				text = bind:Name(),
+                name = bind:Id(),
+                text = bind:Name(),
                 keybind_id = bind:Id(),
                 x_offset = 10,
                 localize = false,
-				desc = bind:Description(),
-				localize_desc = false
+                desc = bind:Description(),
+                localize_desc = false
             })
 
             last_mod = bind:ParentMod()
-		end
-	end
+        end
+    end
 end
 
 function BLTKeybindsMenu:on_escape()
@@ -46,26 +77,26 @@ Hooks:Add("MenuComponentManagerInitialize", "BLT.MenuComponentManagerInitialize"
     RaidMenuHelper:CreateMenu({
         name = "blt_mods",
         name_id = "blt_options_menu_blt_mods",
-        inject_list = "raid_menu_left_options",
         class = BLTModsGui,
+        inject_list = "raid_menu_left_options",
         inject_after = "network",
         icon = "menu_item_cards"
     })
 
     RaidMenuHelper:CreateMenu({
-		name = "blt_keybinds",
-		name_id = "blt_options_menu_keybinds",
-        inject_list = "raid_menu_left_options",
+        name = "blt_keybinds",
+        name_id = "blt_options_menu_keybinds",
         class = BLTKeybindsMenu,
+        inject_list = "raid_menu_left_options",
         inject_after = "network",
         icon = "menu_item_controls"
-	})
+    })
 
     RaidMenuHelper:CreateMenu({
         name = "blt_options",
         name_id = "blt_options_menu_lua_mod_options",
-        inject_list = "raid_menu_left_options",
         class = BLTOptionsMenu,
+        inject_list = "raid_menu_left_options",
         inject_after = "network",
         icon = "menu_item_options"
     })
@@ -73,9 +104,7 @@ Hooks:Add("MenuComponentManagerInitialize", "BLT.MenuComponentManagerInitialize"
     RaidMenuHelper:CreateMenu({
         name = "blt_download_manager",
         name_id = "blt_download_manager",
-        --inject_list = "raid_menu_left_options",
         class = BLTDownloadManagerGui,
-        --inject_after = "network"
     })
 
     RaidMenuHelper:CreateMenu({

--- a/req/ui/BLTCustomComponent.lua
+++ b/req/ui/BLTCustomComponent.lua
@@ -122,7 +122,7 @@ function BLTCustomComponent:_add_custom_back_button()
 	BLT:make_fine_text(back_button)
 	back_button:set_right(self._panel:w() - 10)
 	back_button:set_bottom(self._panel:h() - 10)
-	back_button:set_visible(managers.menu:is_pc_controller())
+	back_button:set_visible(managers.raid_menu:is_pc_controller())
 	self._back_button = back_button
 
 	local bg_back = self._fullscreen_panel:text({

--- a/req/ui/BLTModsGui.lua
+++ b/req/ui/BLTModsGui.lua
@@ -70,11 +70,11 @@ function BLTModsGui:_setup()
 	BLT:make_fine_text(back_button)
 	back_button:set_right(self._panel:w() - 10)
 	back_button:set_bottom(self._panel:h() - 10)
-	back_button:set_visible(managers.menu:is_pc_controller())
+	back_button:set_visible(managers.raid_menu:is_pc_controller())
 	self._back_button = back_button
 	self._custom_buttons[back_button] = {
 		clbk = function()
-			managers.menu:back()
+			managers.raid_menu:close_menu()
 			return true
 		end
 	}

--- a/req/ui/BLTViewModGui.lua
+++ b/req/ui/BLTViewModGui.lua
@@ -40,7 +40,7 @@ function BLTViewModGui:setup()
 		self:_setup_buttons(self._mod)
 		self:refresh()
 	else
-		managers.menu:back(true)
+		managers.raid_menu:close_menu()
 	end
 end
 

--- a/supermod.xml
+++ b/supermod.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
-<mod 
+<mod
     name="RAID-SuperBLT"
     description="The collection of Lua files that allow the BLT hook to function."
     author="ZNix, James Wilkinson, RAIDModding"
     contact="https://discord.gg/9tAtgtGpx9"
-    version="1.2.10"
+    version="1.3.0"
     priority="1001"
     image="assets/guis/blt/icon.png"
     color="255 0 255"
@@ -31,7 +31,7 @@
                 patchnotes_url="https://modworkshop.net/mod/49744?tab=changelog"
                 update_url="https://modworkshop.net/mod/49744"/>
         </update>
-        <update 
+        <update
             identifier="49746"
             provider="modworkshop"
             display_name="WSock Hook DLL"
@@ -65,7 +65,7 @@
         <loc file="russian.json" language="russian" />
         <loc file="spanish.json" language="spanish" />
     </localization>
-    
+
     <hooks>
         <group script_path="lua/raid/">
             <post hook_id="lib/managers/menu/raid_menu/controls/raidguicontrolkeybind" :script_path="RaidGUIControlKeyBind.lua"/>
@@ -101,7 +101,7 @@
             </group>
         </group>
 
-        <group script_path="lua/"> 
+        <group script_path="lua/">
             <post hook_id="core/lib/managers/menu/coremenudata" :script_path="CoreMenuData.lua"/>
             <post hook_id="lib/setups/gamesetup" :script_path="GameSetup.lua"/>
             <post hook_id="lib/setups/menusetup" :script_path="MenuSetup.lua"/>


### PR DESCRIPTION
- new mod options sub menu, matching the style of main menu and options.
  - deprecated `inject_menu = "blt_options"`. use `inject_list` instead.
  - `blt_options` injects can now handle the `icon` param, which can be any regular gui tweak icon.
- injected lists can now automatically be sorted, if `blt_can_sort_list` is passed, and no injection injects by `point`.
  - ..which now applies to the new `blt_options` list.
- reworked MenuComponent creation, so that keyboard interactions should now be somewhat possible to implement in BLTMenus. (might require some more work to be fully usable, see MenuHelper changes)
- other menu fixes:
  - using the keyboard now works in mod options list and should not crash the game any longer.
  - using internal raid_menu helper functions where possible.
  - fixed special_btn_released when chat is focused.
  - BLTMenu: fixed option description screen alignment and made font and color more raid-like.
